### PR TITLE
Convert the base64 encoded data to a Blob to allow for exports of larger tables

### DIFF
--- a/excellentexport.js
+++ b/excellentexport.js
@@ -150,6 +150,7 @@ ExcellentExport = (function() {
         if (addQuotes || replaceDoubleQuotes) {
             fixedValue = '"' + fixedValue + '"';
         }
+
         return fixedValue;
     };
 
@@ -167,18 +168,32 @@ ExcellentExport = (function() {
         return data;
     };
 
+    function createDownloadLink(anchor, base64data, exporttype, filename){
+        if(window.navigator.msSaveBlob) {
+            var blob = b64toBlob(base64data, exporttype);
+            window.navigator.msSaveBlob(blob, filename);
+            return false;
+        } else if(window.URL.createObjectURL) {
+            var blob = b64toBlob(base64data, exporttype);
+            var blobUrl = URL.createObjectURL(blob, exporttype, filename);
+            anchor.href = blobUrl;
+        } else {
+            var hrefvalue = "data:" + type + ";base64," + base64data;
+            anchor.download = filename; 
+            anchor.href = hrefvalue;
+        }
+
+        // Return true to allow the link to work
+        return true;
+    };
+
     var ee = {
         /** @expose */
         excel: function(anchor, table, name) {
             table = get(table);
             var ctx = {worksheet: name || 'Worksheet', table: table.innerHTML};
             var b64 = base64(format(template.excel, ctx));
-            var blob = b64toBlob(b64);
-            var blobUrl = URL.createObjectURL(blob,'application/vnd.ms-excel');
-            
-            anchor.href = blobUrl;
-            // Return true to allow the link to work
-            return true;
+            return createDownloadLink(anchor, b64, 'application/vnd.ms-excel','export.xls');
         },
         /** @expose */
         csv: function(anchor, table, delimiter, newLine) {
@@ -192,10 +207,7 @@ ExcellentExport = (function() {
             table = get(table);
             var csvData = tableToCSV(table);
             var b64 = base64(csvData);
-            var blob = b64toBlob(b64);
-
-            anchor.href = URL.createObjectURL(blob,'application/csv')
-            return true;
+            return createDownloadLink(anchor,b64,'application/csv','export.csv');
         }
     };
 

--- a/excellentexport.js
+++ b/excellentexport.js
@@ -174,7 +174,6 @@ ExcellentExport = (function() {
             table = get(table);
             var ctx = {worksheet: name || 'Worksheet', table: table.innerHTML};
             var b64 = base64(format(template.excel, ctx));
-            var hrefvalue = uri.excel + b64;
             var blob = b64toBlob(b64);
             var blobUrl = URL.createObjectURL(blob,'application/vnd.ms-excel');
             
@@ -192,8 +191,10 @@ ExcellentExport = (function() {
             }
             table = get(table);
             var csvData = tableToCSV(table);
-            var hrefvalue = uri.csv + base64(csvData);
-            anchor.href = hrefvalue;
+            var b64 = base64(csvData);
+            var blob = b64toBlob(b64);
+            
+            anchor.href = var blobUrl = URL.createObjectURL(blob,'application/csv')
             return true;
         }
     };

--- a/excellentexport.js
+++ b/excellentexport.js
@@ -17,6 +17,32 @@
 
 /*jslint browser: true, bitwise: true, plusplus: true, vars: true, white: true */
 
+// function taken from http://stackoverflow.com/a/16245768/2591950
+// author Jeremy Banks http://stackoverflow.com/users/1114/jeremy-banks
+function b64toBlob(b64Data, contentType, sliceSize) {
+  contentType = contentType || '';
+  sliceSize = sliceSize || 512;
+
+  var byteCharacters = atob(b64Data);
+  var byteArrays = [];
+
+  for (var offset = 0; offset < byteCharacters.length; offset += sliceSize) {
+    var slice = byteCharacters.slice(offset, offset + sliceSize);
+
+    var byteNumbers = new Array(slice.length);
+    for (var i = 0; i < slice.length; i++) {
+      byteNumbers[i] = slice.charCodeAt(i);
+    }
+
+    var byteArray = new Uint8Array(byteNumbers);
+
+    byteArrays.push(byteArray);
+  }
+
+  var blob = new Blob(byteArrays, {type: contentType});
+  return blob;
+}
+
 var characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
 var fromCharCode = String.fromCharCode;
 var INVALID_CHARACTER_ERR = (function () {
@@ -147,8 +173,12 @@ ExcellentExport = (function() {
         excel: function(anchor, table, name) {
             table = get(table);
             var ctx = {worksheet: name || 'Worksheet', table: table.innerHTML};
-            var hrefvalue = uri.excel + base64(format(template.excel, ctx));
-            anchor.href = hrefvalue;
+            var b64 = base64(format(template.excel, ctx));
+            var hrefvalue = uri.excel + b64;
+            var blob = b64toBlob(b64);
+            var blobUrl = URL.createObjectURL(blob,'application/vnd.ms-excel');
+            
+            anchor.href = blobUrl;
             // Return true to allow the link to work
             return true;
         },

--- a/excellentexport.js
+++ b/excellentexport.js
@@ -16,10 +16,9 @@
  */
 
 /*jslint browser: true, bitwise: true, plusplus: true, vars: true, white: true */
-
-// function taken from http://stackoverflow.com/a/16245768/2591950
-// author Jeremy Banks http://stackoverflow.com/users/1114/jeremy-banks
 function b64toBlob(b64Data, contentType, sliceSize) {
+    // function taken from http://stackoverflow.com/a/16245768/2591950
+    // author Jeremy Banks http://stackoverflow.com/users/1114/jeremy-banks
   contentType = contentType || '';
   sliceSize = sliceSize || 512;
 
@@ -189,12 +188,13 @@ ExcellentExport = (function() {
             if (newLine !== undefined && newLine) {
                 csvNewLine = newLine;
             }
+            
             table = get(table);
             var csvData = tableToCSV(table);
             var b64 = base64(csvData);
             var blob = b64toBlob(b64);
-            
-            anchor.href = var blobUrl = URL.createObjectURL(blob,'application/csv')
+
+            anchor.href = URL.createObjectURL(blob,'application/csv')
             return true;
         }
     };


### PR DESCRIPTION
# The problem
The current implementation encodes the tables in base64 and creates a download href. But this approach has a limit on how large can the base64 data be for the browser to be able to download/create the file. 
# Where it failed
I had trouble exporting >10000 rows with 2 columns only
# The solution
A Blob object is created from the base64 encoded data, and a the anchor href is just a reference to that blob object. The explanation is taken from a [stack overflow comment](http://stackoverflow.com/a/16245768/2591950) 