### PR TITLE
Including byte order mark

### DIFF
--- a/excellentexport.js
+++ b/excellentexport.js
@@ -129,7 +129,7 @@ ExcellentExport = (function() {
     };
 
     var tableToCSV = function(table) {
-        var data = "";
+        var data = "\ufeff";
         var i, j, row, col;
         for (i = 0; i < table.rows.length; i++) {
             row = table.rows[i];


### PR DESCRIPTION
Including byte order mark before create the CSV Data for export the encoding correctly