### PR TITLE
Fix problem with node inside td element

### DIFF
--- a/excellentexport.js
+++ b/excellentexport.js
@@ -96,7 +96,7 @@ const ExcellentExport = function() {
     const tableToArray = function(table) {
         var tableInfo = Array.prototype.map.call(table.querySelectorAll('tr'), function(tr) {
             return Array.prototype.map.call(tr.querySelectorAll('th,td'), function(td) {
-                return td.innerHTML;
+                return td.firstChild && td.firstChild.nodeType !== 3 ? td.firstChild.innerHTML : td.innerHTML;
             });
         });
         return tableInfo;


### PR DESCRIPTION
I come across situation when Angular added on its own some **`<span>`** element  inside **`<td>`** element in my table and **`.innerHtml`** didn't work correctly. Result was **`<span>text</span>`** inside cell in excel file. So I thought that you can check if child node exists and then check if it is of type TEXT (https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType). It's my take on the issue but I get it that you can have better idea what to do about it. Good luck and thanks for awesome lib :).